### PR TITLE
Enable mod_proxy_wstunnel on F30

### DIFF
--- a/ansible/roles/real-httpd/files/httpd/conf/httpd.conf
+++ b/ansible/roles/real-httpd/files/httpd/conf/httpd.conf
@@ -84,6 +84,7 @@ LoadModule alias_module modules/mod_alias.so
 LoadModule rewrite_module modules/mod_rewrite.so
 LoadModule proxy_module modules/mod_proxy.so
 LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
 #LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
 #LoadModule proxy_connect_module modules/mod_proxy_connect.so
 #LoadModule cache_module modules/mod_cache.so


### PR DESCRIPTION
I've been doing some experiments aiming towards a scripts-based ctlfish, but for it to work scripts needs to be able to deal with websockets.